### PR TITLE
Fixed Tinytest to be a require

### DIFF
--- a/counter-tests.coffee
+++ b/counter-tests.coffee
@@ -1,3 +1,5 @@
+Tinytest = require('tinytest')
+
 Tinytest.add 'mongo-counter delete counters', (test) ->
   deleteCounters('_counters')
 Tinytest.add 'mongo-counter inc counters', (test) ->


### PR DESCRIPTION
This fixes an issue I ran into after upgrading to Meteor 1.4.1

The test code gets executed even when running without tests. This is well documented here - http://stackoverflow.com/questions/25084633/package-on-test-runs-even-when-not-testing

Requiring Tinytest allows the code to run during dependency mapping
